### PR TITLE
Shield async access with lock and misc fixes

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tox-env: ["py312", "py313"]
+        tox-env: ["py312", "py313", "py314"]
     runs-on: ubuntu-latest
     container: fedorapython/fedora-python-tox:latest
     steps:

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -20,10 +20,12 @@ def image_file(tmp_path):
 
 
 class TestExifToolWrapper:
-    @pytest.mark.parametrize("with_common_args", (True, False))
+    @pytest.mark.parametrize(
+        "with_common_args", (True, False), ids=("with-common-args", "without-common-args")
+    )
     @mock.patch("subprocess.Popen")
-    def test_pipe(self, Popen, with_common_args):
-        """Test the `ExifToolWrapper.pipe` property."""
+    def test__pipe(self, Popen, with_common_args):
+        """Test the `ExifToolWrapper._pipe` property."""
         Popen.return_value = sentinel = object()
 
         if with_common_args:
@@ -33,9 +35,9 @@ class TestExifToolWrapper:
 
         wrapper = ExifToolWrapper(common_args=common_args)
 
-        assert wrapper.pipe == sentinel
+        assert wrapper._pipe is sentinel
         # test that pipe is only created once
-        assert wrapper.pipe == sentinel
+        assert wrapper._pipe is sentinel
 
         Popen.assert_called_once()
         (popen_args,), kwargs = Popen.call_args

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.12.0
-envlist = py{312,313},lint,format
+envlist = py{312,313,314},lint,format
 isolated_build = true
 skip_missing_interpreters = true
 


### PR DESCRIPTION
commit fa8c3570f31fce2d94d1f5c6784417111be5ebbc
Author: Nils Philippsen <nils@tiptoe.de>
Date:   Fri Jul 25 11:58:09 2025 +0200

    Rework using and testing pipe
    
    Use @cached_property and rename the property (it’s internal). Also,
    check for identity with the sentinel when testing.
    
    Signed-off-by: Nils Philippsen <nils@tiptoe.de>

commit 41a66a78468f531250bcebe9b101987fad601760
Author: Nils Philippsen <nils@tiptoe.de>
Date:   Fri Jul 25 12:09:30 2025 +0200

    Test *_many() methods explicitly
    
    Signed-off-by: Nils Philippsen <nils@tiptoe.de>

commit 2e655e4258b78f615f66c5e0dd470f10ca5184de
Author: Nils Philippsen <nils@tiptoe.de>
Date:   Fri Jul 25 12:10:04 2025 +0200

    Shield async access with lock
    
    Fixes: #53
    
    Signed-off-by: Nils Philippsen <nils@tiptoe.de>

commit 8c76fb2edb985be43e10f82d5260b9b6d8d6c5f9
Author: Nils Philippsen <nils@tiptoe.de>
Date:   Fri Jul 25 12:16:53 2025 +0200

    Test with Python 3.14
    
    Signed-off-by: Nils Philippsen <nils@tiptoe.de>